### PR TITLE
(maint) Update EL to get build requirements from platform file

### DIFF
--- a/configs/components/_base-ruby-selinux.rb
+++ b/configs/components/_base-ruby-selinux.rb
@@ -29,11 +29,12 @@ else
 end
 
 pkg.build_requires "ruby-#{ruby_version}"
-pkg.build_requires "swig"
-pkg.build_requires "libsepol"
-pkg.build_requires "libsepol-devel"
-pkg.build_requires "libselinux-devel"
-
+unless platform.is_el?
+  pkg.build_requires "swig"
+  pkg.build_requires "libsepol"
+  pkg.build_requires "libsepol-devel"
+  pkg.build_requires "libselinux-devel"
+end
 cc = "/opt/pl-build-tools/bin/gcc"
 system_include = "-I/usr/include"
 ruby = "#{ruby_bindir}/ruby -rrbconfig"

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -90,7 +90,9 @@ if platform.is_aix?
 elsif platform.is_deb?
   pkg.build_requires 'zlib1g-dev'
 elsif platform.is_rpm?
-  pkg.build_requires 'zlib-devel'
+  unless platform.is_el?
+    pkg.build_requires 'zlib-devel'
+  end
 elsif platform.is_windows?
   pkg.build_requires "pl-zlib-#{platform.architecture}"
 end

--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -50,13 +50,15 @@ component 'augeas' do |pkg, settings, platform|
   end
 
   if platform.is_rpm? && !platform.is_aix?
-    pkg.build_requires 'readline-devel'
-    pkg.build_requires 'pkgconfig'
+    unless platform.is_el?
+      pkg.build_requires 'readline-devel'
+      pkg.build_requires 'pkgconfig'
 
-    if platform.is_cisco_wrlinux?
-      pkg.requires 'libreadline6'
-    else
-      pkg.requires 'readline'
+      if platform.is_cisco_wrlinux?
+        pkg.requires 'libreadline6'
+      else
+        pkg.requires 'readline'
+      end
     end
 
     if platform.architecture =~ /aarch64|ppc64le|s390x/

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -31,7 +31,9 @@ component "boost" do |pkg, settings, platform|
   # Package Dependency Metadata
 
   # Build Requirements
-  if platform.is_cross_compiled_linux?
+  if platform.is_el?
+  #
+  elsif platform.is_cross_compiled_linux?
     pkg.build_requires "pl-binutils-#{platform.architecture}"
     pkg.build_requires "pl-gcc-#{platform.architecture}"
   elsif platform.is_aix?
@@ -46,7 +48,7 @@ component "boost" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc"
     # Various Linux platforms
     case platform.name
-    when /el|fedora/
+    when /fedora/
       pkg.build_requires 'bzip2-devel'
       pkg.build_requires 'zlib-devel'
     when /sles-(11|12)/

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -9,9 +9,7 @@ component 'curl' do |pkg, settings, platform|
     pkg.apply_patch 'resources/patches/curl/curl-7.55.1-aix-poll.patch'
   end
 
-  if settings[:system_openssl]
-    pkg.build_requires 'openssl-devel'
-  else
+  unless settings[:system_openssl]
     pkg.build_requires "openssl-#{settings[:openssl_version]}"
   end
 

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -22,7 +22,9 @@ component "libxml2" do |pkg, settings, platform|
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
   else
-    pkg.build_requires "make"
+    unless platform.is_el?
+      pkg.build_requires "make"
+    end
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   end

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -31,7 +31,9 @@ component "libxslt" do |pkg, settings, platform|
     pkg.environment "LDFLAGS", settings[:ldflags]
     pkg.environment "CFLAGS", settings[:cflags]
   else
-    pkg.build_requires "make"
+    unless platform.is_el?
+      pkg.build_requires "make"
+    end
     pkg.environment "LDFLAGS" => settings[:ldflags]
     pkg.environment "CFLAGS" => settings[:cflags]
   end

--- a/configs/components/openssl-1.0.2.rb
+++ b/configs/components/openssl-1.0.2.rb
@@ -85,7 +85,7 @@ component 'openssl' do |pkg, settings, platform|
     if platform.name =~ /debian-8-arm/
       pkg.build_requires 'xutils-dev'
     end
-  elsif platform.is_linux?
+  elsif platform.is_linux? && !platform.is_el?
     pkg.build_requires 'pl-gcc'
   end
 

--- a/configs/components/openssl-1.1.0.rb
+++ b/configs/components/openssl-1.1.0.rb
@@ -86,15 +86,6 @@ component 'openssl' do |pkg, settings, platform|
       end
     pkg.build_requires 'pl-gcc'
     end
-  elsif platform.is_linux?
-    if platform.name =~ /^el-5/
-      # OpenSSL 1.1.0's configure script requires perl >= version 5.10, but the
-      # default version on EL 5 is 5.8.8. Install a newer perl just so we can
-      # run the configure script:
-      pkg.build_requires 'pl-perl'
-    end
-      # pkg.build_requires 'xutils-dev'
-      # pkg.apply_patch 'resources/patches/openssl/openssl-1.0.0l-use-gcc-instead-of-makedepend.patch'
   end
 
   ###########

--- a/configs/components/puppet-ca-bundle.rb
+++ b/configs/components/puppet-ca-bundle.rb
@@ -1,9 +1,7 @@
 component "puppet-ca-bundle" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet-ca-bundle.json")
 
-  if settings[:system_openssl]
-    pkg.build_requires 'openssl-devel'
-  else
+  unless settings[:system_openssl]
     pkg.build_requires "openssl-#{settings[:openssl_version]}"
   end
 

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -11,6 +11,8 @@ component "runtime-agent" do |pkg, settings, platform|
       pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-gcc-4.8.2-1.#{platform.architecture}.pkg.gz"
       pkg.build_requires "http://pl-build-tools.delivery.puppetlabs.net/solaris/10/pl-binutils-2.27-1.#{platform.architecture}.pkg.gz"
     end
+  elsif platform.is_el?
+    # do nothing, build requirements come from platform files
   elsif platform.is_cross_compiled_linux? || platform.name =~ /solaris-11/
     pkg.build_requires "pl-binutils-#{platform.architecture}"
     pkg.build_requires "pl-gcc-#{platform.architecture}"

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -20,7 +20,7 @@ component "yaml-cpp" do |pkg, settings, platform|
     pkg.build_requires "cmake"
   elsif platform.is_macos?
     pkg.build_requires "cmake"
-  elsif platform.is_aix?
+  elsif platform.is_aix? || platform.is_el?
     # Moved to platform def, do nothing
   else
     pkg.build_requires "pl-gcc"

--- a/configs/platforms/el-5-i386.rb
+++ b/configs/platforms/el-5-i386.rb
@@ -4,7 +4,32 @@ platform "el-5-i386" do |plat|
   plat.servicetype "sysv"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch' > /etc/yum.repos.d/build-tools.repo"
+  plat.provision_with "echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch' > /etc/yum.repos.d/build-tools.repo"
+  packages = [
+    "autoconf",
+    "automake",
+    "bzip2-devel",
+    "createrepo",
+    "gcc",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "pl-perl",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install -y --nogpgcheck "
   plat.vmpooler_template "centos-5-i386"
 end

--- a/configs/platforms/el-5-x86_64.rb
+++ b/configs/platforms/el-5-x86_64.rb
@@ -4,7 +4,32 @@ platform "el-5-x86_64" do |plat|
   plat.servicetype "sysv"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo"
+  plat.provision_with "echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo"
+  packages = [
+    "autoconf",
+    "automake",
+    "bzip2-devel",
+    "createrepo",
+    "gcc",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "pl-perl",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
   plat.vmpooler_template "centos-5-x86_64"
 end

--- a/configs/platforms/el-6-i386.rb
+++ b/configs/platforms/el-6-i386.rb
@@ -4,7 +4,31 @@ platform "el-6-i386" do |plat|
   plat.servicetype "sysv"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-#{plat.get_os_name}-#{plat.get_os_version}.noarch.rpm"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "bzip2-devel",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-6-i386"
 end

--- a/configs/platforms/el-6-s390x.rb
+++ b/configs/platforms/el-6-s390x.rb
@@ -5,7 +5,31 @@ platform "el-6-s390x" do |plat|
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/s390x/pl-build-tools-s390x.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/x86_64/pl-build-tools-x86_64.repo"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-binutils-#{self._platform.architecture}",
+    "pl-cmake",
+    "pl-gcc-#{self._platform.architecture}",
+    "pl-ruby",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.cross_compiled true
   plat.vmpooler_template "redhat-6-x86_64"

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -4,7 +4,31 @@ platform "el-6-x86_64" do |plat|
   plat.servicetype "sysv"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/x86_64/pl-build-tools-release-6-1.noarch.rpm"
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils"
+  packages = [
+    "autoconf",
+    "automake",
+    "bzip2-devel",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-6-x86_64"
 end

--- a/configs/platforms/el-7-aarch64.rb
+++ b/configs/platforms/el-7-aarch64.rb
@@ -5,7 +5,31 @@ platform "el-7-aarch64" do |plat|
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/aarch64/pl-build-tools-aarch64.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-binutils-#{self._platform.architecture}",
+    "pl-cmake",
+    "pl-gcc-#{self._platform.architecture}",
+    "pl-ruby",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.cross_compiled true
   plat.vmpooler_template "redhat-7-x86_64"

--- a/configs/platforms/el-7-ppc64le.rb
+++ b/configs/platforms/el-7-ppc64le.rb
@@ -5,7 +5,31 @@ platform "el-7-ppc64le" do |plat|
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/ppc64le/pl-build-tools-ppc64le.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-binutils-#{self._platform.architecture}",
+    "pl-cmake",
+    "pl-gcc-#{self._platform.architecture}",
+    "pl-ruby",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.cross_compiled true
   plat.vmpooler_template "redhat-7-x86_64"

--- a/configs/platforms/el-7-s390x.rb
+++ b/configs/platforms/el-7-s390x.rb
@@ -5,7 +5,31 @@ platform "el-7-s390x" do |plat|
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/s390x/pl-build-tools-s390x.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/el/7/x86_64/pl-build-tools-x86_64.repo"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-binutils-#{self._platform.architecture}",
+    "pl-cmake",
+    "pl-gcc-#{self._platform.architecture}",
+    "pl-ruby",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.cross_compiled true
   plat.vmpooler_template "redhat-7-x86_64"

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -5,7 +5,31 @@ platform "el-7-x86_64" do |plat|
 
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "bzip2-devel",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-7-x86_64"
 end

--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -4,7 +4,31 @@ platform "redhatfips-7-x86_64" do |plat|
   plat.servicetype "systemd"
 
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "java-1.8.0-openjdk-devel",
+    "libsepol",
+    "libsepol-devel",
+    "libselinux-devel",
+    "make",
+    "openssl-devel",
+    "pkgconfig",
+    "pl-cmake",
+    "pl-gcc",
+    "readline-devel",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "rpmdevtools",
+    "swig",
+    "yum-utils",
+    "zlib-devel",
+  ]
+  plat.provision_with("yum install -y --nogpgcheck  #{packages.join(' ')}")
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "redhat-fips-7-x86_64"
 end


### PR DESCRIPTION
This commit migrates build requirements from pkg.build_requires statements in
component files to platform files.

As part of this, statements have been added pruning out EL builds from using
pkg.build_requires at all.