### PR TITLE
(maint) Move Windows build requires to platform files

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -73,11 +73,6 @@ elsif platform.is_solaris?
 elsif platform.is_cross_compiled_linux?
   pkg.build_requires "runtime-#{settings[:runtime_project]}"
   pkg.build_requires 'pl-ruby'
-elsif platform.is_windows?
-  pkg.build_requires "pl-gdbm-#{platform.architecture}"
-  pkg.build_requires "pl-iconv-#{platform.architecture}"
-  pkg.build_requires "pl-libffi-#{platform.architecture}"
-  pkg.build_requires "pl-pdcurses-#{platform.architecture}"
 end
 
 if platform.is_aix? || platform.is_deb?
@@ -86,8 +81,6 @@ elsif platform.is_rpm?
   unless platform.is_el? || platform.is_sles? || platform.is_fedora?
     pkg.build_requires 'zlib-devel'
   end
-elsif platform.is_windows?
-  pkg.build_requires "pl-zlib-#{platform.architecture}"
 end
 
 #######

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -11,8 +11,7 @@ component "runtime-agent" do |pkg, settings, platform|
   elsif platform.is_aix?
     libdir = "/opt/pl-build-tools/lib/gcc/powerpc-ibm-aix#{platform.os_version}.0.0/5.2.0/"
   elsif platform.is_windows?
-    # We only need zlib because curl is dynamically linking against zlib
-    pkg.build_requires "pl-zlib-#{platform.architecture}"
+    # do nothing, build requirements come from platform file
   else
     pkg.build_requires "pl-gcc"
   end

--- a/configs/components/yaml-cpp.rb
+++ b/configs/components/yaml-cpp.rb
@@ -10,8 +10,7 @@ component "yaml-cpp" do |pkg, settings, platform|
     pkg.build_requires "pl-gcc-#{platform.architecture}"
     pkg.build_requires "pl-cmake"
   elsif platform.is_windows?
-    pkg.build_requires "pl-toolchain-#{platform.architecture}"
-    pkg.build_requires "cmake"
+    # Do nothing, build requirements come from platform files
   else
     pkg.build_requires "pl-gcc"
     pkg.build_requires "make"

--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -16,8 +16,21 @@ platform "windows-2012r2-x64" do |plat|
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
+  packages = [
+    "cmake",
+    "pl-gdbm-#{self._platform.architecture}",
+    "pl-iconv-#{self._platform.architecture}",
+    "pl-libffi-#{self._platform.architecture}",
+    "pl-pdcurses-#{self._platform.architecture}",
+    "pl-toolchain-#{self._platform.architecture}",
+    "pl-zlib-#{self._platform.architecture}",
+    "mingw-w64 -version 5.2.0 -debug",
+    "Wix310 -version 3.10.2 -debug -x86"
+  ]
+
+  packages.each do |name|
+    plat.provision_with("C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress #{name}")
+  end
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -11,13 +11,26 @@ platform "windows-2012r2-x86" do |plat|
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety
-  plat.provision_with "mkdir -p C:/tools"
+  plat.provision_with "mkdir C:/tools"
   # We don't want to install any packages from the chocolatey repo by accident
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey"
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
 
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress"
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install -y Wix310 -version 3.10.2 -debug -x86 --no-progress"
+  packages = [
+    "cmake",
+    "pl-gdbm-#{self._platform.architecture}",
+    "pl-iconv-#{self._platform.architecture}",
+    "pl-libffi-#{self._platform.architecture}",
+    "pl-pdcurses-#{self._platform.architecture}",
+    "pl-toolchain-#{self._platform.architecture}",
+    "pl-zlib-#{self._platform.architecture}",
+    "mingw-w32 -version 5.2.0 -debug -x86",
+    "Wix310 -version 3.10.2 -debug -x86"
+  ]
+
+  packages.each do |name|
+    plat.provision_with("C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress #{name}")
+  end
   # We use cache-location in the following install because msvc has several long paths
   # if we do not update the cache location choco will fail because paths get too long
   plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"


### PR DESCRIPTION
This commit moves the build requirements from component files to the platform
files.